### PR TITLE
chore: migrate to pnpm 11 via corepack and test Node 22/24/26

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -21,24 +21,31 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v6
+
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: 24
+        cache: 'pnpm'
+
+    - name: Enable Corepack
+      run: corepack enable
 
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
 
-    - name: Build    
+    - name: Build
       run: pnpm build
 
-    - name: Testing    
+    - name: Testing
       run: pnpm test:ci
-      
+
     - name: Code Coverage
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: Hyphen/nodejs-toggle-sdk
         files: ./coverage/lcov.info
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
     types: [released]
 
 permissions:
-  contents: read    
+  contents: read
 
 env:
   HYPHEN_PUBLIC_API_KEY: ${{ secrets.HYPHEN_PUBLIC_API_KEY }}
@@ -19,18 +19,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v6
+
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:
         node-version: 24
+        cache: 'pnpm'
+
+    - name: Enable Corepack
+      run: corepack enable
 
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
 
-    - name: Build    
+    - name: Build
       run: pnpm build
 
-    - name: Testing    
+    - name: Testing
       run: pnpm test:ci
 
     - name: Publish
@@ -39,4 +47,3 @@ jobs:
         npm publish --ignore-scripts --access public
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,21 +21,28 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['22', '24']
+        node-version: ['22', '24', '26']
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v6
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'pnpm'
+
+    - name: Enable Corepack
+      run: corepack enable
 
     - name: Install Dependencies
-      run: npm install pnpm -g && pnpm install
+      run: pnpm install
 
-    - name: Build    
+    - name: Build
       run: pnpm build
 
-    - name: Testing    
+    - name: Testing
       run: pnpm test:ci
-

--- a/package.json
+++ b/package.json
@@ -54,5 +54,6 @@
   ],
   "dependencies": {
     "hookified": "^2.1.1"
-  }
+  },
+  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
+allowBuilds:
+  '@swc/core': true
+  esbuild: true
+  unrs-resolver: true
 minimumReleaseAge: 2880
-onlyBuiltDependencies:
-  - '@swc/core'
-  - esbuild
-  - unrs-resolver


### PR DESCRIPTION
## Summary

Migrates the SDK from pnpm 10 to **pnpm 11** using corepack, and refreshes the CI tooling and Node.js test matrix.

## Changes

- **pnpm 11 via corepack** — added `"packageManager": "pnpm@11.8.0+sha512…"` to `package.json` (generated with `corepack use pnpm@11.8.0`). pnpm now resolves from this field rather than the previous unpinned `npm install pnpm -g`.
- **`allowBuilds` config** — pnpm 11 **removed** `onlyBuiltDependencies` (and `neverBuiltDependencies`, `ignoredBuiltDependencies`, etc.), replacing them with the unified `allowBuilds` map. `pnpm-workspace.yaml` now uses:
  ```yaml
  allowBuilds:
    '@swc/core': true
    esbuild: true
    unrs-resolver: true
  ```
  Without this, pnpm 11 reports `ERR_PNPM_IGNORED_BUILDS` for `@swc/core` and `esbuild`.
- **Node test matrix** — `tests.yaml` now runs against Node **22, 24, and 26**.
- **Node 24 stays the LTS** — `.nvmrc` is unchanged (`24`) and the single-version workflows (`release.yaml`, `code-coverage.yaml`) continue to use Node 24.
- **Workflow pnpm setup** — all workflows now use `pnpm/action-setup@v6` + `corepack enable`, with the pnpm store cached via `actions/setup-node` (`cache: 'pnpm'`), replacing `npm install pnpm -g && pnpm install`. This matches the pattern used in the sibling `Hyphen/nodejs-sdk` and `jaredwray/cacheable` repos.

## Verification

Run locally with pnpm 11.8.0:

- `pnpm install --frozen-lockfile` — ✅ clean, build scripts now run (`@swc/core`, `esbuild`), no ignored-builds error
- `pnpm build` — ✅ passes
- `pnpm test` — ✅ 151/156 pass; the 5 failures are the live-API `Toggle Evaluations` tests that require `HYPHEN_PUBLIC_API_KEY` / `HYPHEN_APPLICATION_ID` (provided via secrets in CI, absent locally) — unrelated to this change.

> Note: the request referenced `pnpm/setup-action`; the actual published action is [`pnpm/action-setup`](https://github.com/pnpm/action-setup) (`pnpm/setup-action` does not exist), so that is what's used here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVGY8SQ7gQP8PL5BvWDFBN)_