### PR TITLE
root - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install pnpm
       uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'
@@ -44,7 +44,7 @@ jobs:
       run: pnpm test:ci
 
     - name: Code Coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: Hyphen/nodejs-toggle-sdk

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -70,6 +70,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install pnpm
       uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
         cache: 'pnpm'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,13 +24,13 @@ jobs:
         node-version: ['22', '24', '26']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install pnpm
       uses: pnpm/action-setup@v6
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'


### PR DESCRIPTION
## Summary
Upgrade all GitHub Actions `uses:` references to their latest major versions — dev phase, PR 3 (final dev group).

## Versions
- `actions/checkout` v4 (v3 in `codeql.yaml`) → **v7**
- `actions/setup-node` v4 → **v6**
- `codecov/codecov-action` v5 → **v7**
- `github/codeql-action` (init/autobuild/analyze) v2 → **v4**
- `pnpm/action-setup` already at latest major v6 — unchanged

## Checks
- [x] All 4 workflow YAML files parse
- [x] Major-only pin style preserved (`@vX`)
- [x] Input compatibility verified for the inputs actually used: `setup-node` `node-version`/`cache`; `codecov` `token`/`slug`/`files`; `codeql` `languages`/`category` — unchanged across these majors

## Breaking notes
Tagged `(breaking)` per convention because action majors changed, but no workflow edits beyond the version refs were needed. Practical effects:
- `actions/checkout` v5+ / `actions/setup-node` v5+ run on the Node 24 action runtime (was Node 20) — also clears the "Node 20 is deprecated" CI warnings.
- `github/codeql-action` v2 was **deprecated** by GitHub (uploads rejected); v4 is the current supported line. This also fixes `codeql.yaml` still being on `checkout@v3`.
- `codecov/codecov-action` v7 retains the `token`/`slug`/`files` inputs.
- `release.yaml` only runs on `release`/dispatch, so its checkout/setup-node bumps aren't exercised by this PR's CI; they mirror `tests.yaml` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXjL3LurbiGcLiiep7Fnvr)_