### PR TITLE
root - chore: upgrade @hyphen/sdk (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@faker-js/faker": "^10.5.0",
-    "@hyphen/sdk": "^3.0.1",
+    "@hyphen/sdk": "^4.0.0",
     "@swc/core": "^1.15.41",
     "@types/node": "^24.13.2",
     "@vitest/coverage-v8": "^4.1.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^10.5.0
         version: 10.5.0
       '@hyphen/sdk':
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^4.0.0
+        version: 4.0.0
       '@swc/core':
         specifier: ^1.15.41
         version: 1.15.41
@@ -154,8 +154,8 @@ packages:
   '@cacheable/memory@2.0.8':
     resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
 
-  '@cacheable/net@2.0.7':
-    resolution: {integrity: sha512-yItascYmXnV324/43u+t8/DaljXV0dxfwC/4BfXm38SiKWBONgBehNa6FskfRL4HnogmeUrWKiU+J6CXGZ4eLw==}
+  '@cacheable/net@2.0.8':
+    resolution: {integrity: sha512-uSRwS6krnRsOM65F1S2IlkGQA+VoxkrbrkBwmbFxDj/ihdSHtDpLMIaKguM0A++dUXTha2cY146yNOqwv8gAPQ==}
 
   '@cacheable/utils@2.4.1':
     resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
@@ -329,9 +329,9 @@ packages:
     resolution: {integrity: sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==}
     engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
 
-  '@hyphen/sdk@3.0.1':
-    resolution: {integrity: sha512-+x93sgMyMLL+FHt651m5zdy77Shed9GpfwqwxKfLAK7tJXkytimOQqANRIfMmXoO5iwVBB8aJF70MRVvlv3b8g==}
-    engines: {node: '>=20.12.0'}
+  '@hyphen/sdk@4.0.0':
+    resolution: {integrity: sha512-OO3ALigqBDPBv543CxNf2GG7+/zuLZY+HMCDYM84r7OvDLCOslXpLcjj6vQNqyQOkGfZ4jLrh7G4VL8cJSvOEw==}
+    engines: {node: ^22.18.0 || >=24.0.0}
 
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
@@ -956,8 +956,8 @@ packages:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
     engines: {node: '>=20.19.0'}
 
-  cacheable@2.3.4:
-    resolution: {integrity: sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==}
+  cacheable@2.3.5:
+    resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
 
   camelcase-keys@6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
@@ -1117,6 +1117,10 @@ packages:
 
   hookified@2.1.1:
     resolution: {integrity: sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==}
+
+  hookified@3.0.0:
+    resolution: {integrity: sha512-x+jzDjd9CWxdgl6u/K4pjnvw7PZx6ZSpiPGAV43uXlJiJy7r2jIEUxxU1Cv7+rwy1GK5Qt5S+Jp7n81DpcUvTA==}
+    engines: {node: '>=22.18.0'}
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -1380,8 +1384,8 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
-  qified@0.9.1:
-    resolution: {integrity: sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==}
+  qified@0.10.1:
+    resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
     engines: {node: '>=20'}
 
   quansync@1.0.0:
@@ -1853,9 +1857,9 @@ snapshots:
       hookified: 1.15.1
       keyv: 5.6.0
 
-  '@cacheable/net@2.0.7':
+  '@cacheable/net@2.0.8':
     dependencies:
-      cacheable: 2.3.4
+      cacheable: 2.3.5
       hookified: 1.15.1
       http-cache-semantics: 4.2.0
       undici: 7.24.7
@@ -1961,12 +1965,11 @@ snapshots:
 
   '@faker-js/faker@10.5.0': {}
 
-  '@hyphen/sdk@3.0.1':
+  '@hyphen/sdk@4.0.0':
     dependencies:
-      '@cacheable/net': 2.0.7
-      '@faker-js/faker': 10.5.0
-      cacheable: 2.3.4
-      hookified: 2.1.1
+      '@cacheable/net': 2.0.8
+      cacheable: 2.3.5
+      hookified: 3.0.0
       pino: 10.3.1
 
   '@jest/schemas@29.6.3':
@@ -2404,13 +2407,13 @@ snapshots:
 
   cac@7.0.0: {}
 
-  cacheable@2.3.4:
+  cacheable@2.3.5:
     dependencies:
       '@cacheable/memory': 2.0.8
       '@cacheable/utils': 2.4.1
       hookified: 1.15.1
       keyv: 5.6.0
-      qified: 0.9.1
+      qified: 0.10.1
 
   camelcase-keys@6.2.2:
     dependencies:
@@ -2580,6 +2583,8 @@ snapshots:
   hookified@1.15.1: {}
 
   hookified@2.1.1: {}
+
+  hookified@3.0.0: {}
 
   hosted-git-info@2.8.9: {}
 
@@ -2824,7 +2829,7 @@ snapshots:
 
   process-warning@5.0.0: {}
 
-  qified@0.9.1:
+  qified@0.10.1:
     dependencies:
       hookified: 2.1.1
 


### PR DESCRIPTION
## Summary
Upgrade `@hyphen/sdk` to v4 — runtime phase, PR 1 of 2.

## Versions
- `@hyphen/sdk` `3.0.1` → **`4.0.0`** (major)

## Impact
`@hyphen/sdk` is a **dev/test-only** dependency, used in exactly one place — `env()` in `test/index-evals.test.ts`. In v4 the `env` export and its signature (`env(options?: EnvOptions): void`) are **unchanged**, so no code changes are required. No effect on the published package or its consumers. (Other v4 API changes — e.g. `ToggleEvents` becoming a type-only export, dual ESM/CJS type files — aren't used here.)

## Tests
- [x] `pnpm build` passes
- [x] `pnpm test` — 151/156 pass; no new failures

The only failures are the 5 live-platform `test/index-evals.test.ts` tests (need `HYPHEN_PUBLIC_API_KEY` / `HYPHEN_APPLICATION_ID`, absent in the local sandbox) — identical to `main`, unrelated to this change. CI has those secrets.

## Breaking notes
Labeled `(breaking)` only because the dependency crossed a major version; for this repo there is **no breaking impact** (dev-only usage, `env()` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXjL3LurbiGcLiiep7Fnvr)_