### PR TITLE
root - chore: upgrade hookified (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "hookified": "^2.1.1"
+    "hookified": "^3.0.0"
   },
   "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       hookified:
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.0


### PR DESCRIPTION
## Summary
Upgrade `hookified` to v3 — runtime phase, PR 2 of 2 (final dependency-management item).

## Versions
- `hookified` `2.1.1` → **`3.0.0`** (major)

## Impact
`hookified` is the SDK's one runtime `dependency`; `Toggle extends Hookified`. The APIs the SDK uses are **unchanged** in v3:
- The `Hookified` constructor still accepts `{ throwOnEmptyListeners: false }` — this is what keeps `emit(ToggleEvents.Error, …)` from re-throwing when no listener is attached, so the SDK can swallow eval errors and return the caller's default (`src/index.ts:55`).
- `emit()` is unchanged; v3 only **adds** APIs (`ParallelHook`).

No source changes required.

## Tests
- [x] `pnpm build` passes (hookified is bundled into the browser build)
- [x] `pnpm test` — 151/156 pass; no new failures
- [x] Error-path test (`index.test.ts` "should return defaultValue when error occurs") passes → `throwOnEmptyListeners: false` behavior preserved

The only failures are the 5 live-platform `test/index-evals.test.ts` tests (need `HYPHEN_PUBLIC_API_KEY` / `HYPHEN_APPLICATION_ID`, absent in the local sandbox) — identical to `main`, unrelated to this change. CI has those secrets.

## Breaking notes
Labeled `(breaking)` because the dependency crossed a major version. For this repo there's no breaking impact — the constructor option and `emit()` behavior the SDK depends on are unchanged and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXjL3LurbiGcLiiep7Fnvr)_