### PR TITLE
release: v1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyphen/browser-sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Hyphen SDK for Browser / Javascript",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release summary
Dependency and tooling upgrades since v1.1.2 — patch release. No public API changes.

## @hyphen/browser-sdk@1.1.3 — 2026-06-20

Dependency and tooling upgrades: hookified v3, @hyphen/sdk v4, TypeScript 6.0.3, pnpm 11, and CI action majors.

### Internal
- migrate to pnpm 11 via corepack and test Node 22/24/26 (83b6439, #62)
- upgrade code quality dependencies (adc44c4, #61)
- upgrade TypeScript and build tooling (6ae7256, #63)
- upgrade GitHub Actions to latest major versions (a03a166, #64)
- upgrade @hyphen/sdk to v4 (a2e0331, #65)
- upgrade hookified to v3 (68d9027, #66)

### Contributors
- @jaredwray (6)

### Full List of Changes
- chore: migrate to pnpm 11 via corepack and test Node 22/24/26 by @jaredwray in #62
- root - chore: upgrade code quality dependencies by @jaredwray in #61
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #63
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #64
- root - chore: upgrade @hyphen/sdk (breaking) by @jaredwray in #65
- root - chore: upgrade hookified (breaking) by @jaredwray in #66

**Full diff:** https://github.com/Hyphen/browser-sdk/compare/v1.1.2...v1.1.3

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds
- [x] `pnpm test:ci` — 151/156 pass locally; the 5 failures are the live-platform tests in `test/index-evals.test.ts` that require `HYPHEN_PUBLIC_API_KEY` / `HYPHEN_APPLICATION_ID` (absent in the sandbox, configured as secrets in CI) — identical to `main`, unrelated to this bump
- [x] No uncommitted changes outside the version bump

## Post-merge
Merge then create a GitHub Release at tag `v1.1.3` — the `release.yaml` workflow publishes to npm on the Release `released` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrVMfUuxgR7ohDyF4chFAp

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrVMfUuxgR7ohDyF4chFAp)_