### PR TITLE
root - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24
         cache: 'pnpm'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       uses: pnpm/action-setup@v6
 
     - name: Use Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 24
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
       uses: pnpm/action-setup@v6
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.

**What kind of change does this PR introduce?**

CI maintenance (`chore`). Only `.github/workflows/` changes — no source, no `package.json`, no lockfile. Coverage is unchanged at 100% statements / 94.44% branches.

## Summary

Upgrades the GitHub Actions group. Third group in the dependency-management run, following #69 and #70.

## Versions

- `actions/setup-node` `v6` → `v7` — `code-coverage.yaml`, `release.yaml`, `tests.yaml`

Already on their latest major and left unchanged: `actions/checkout@v7`, `pnpm/action-setup@v6`, `codecov/codecov-action@v7`, `github/codeql-action@v4`. The existing `@vX` pin style is preserved.

## Tests

- [x] All four workflow files re-parse as valid YAML
- [x] `pnpm build` passes
- [x] `pnpm test` passes — 156 tests across 3 files, 100% statements / 94.44% branches
- [x] `tests.yaml` and `code-coverage.yaml` exercise `setup-node@v7` directly on this PR's own checks

## Breaking notes

`setup-node@v7`'s only breaking change is an internal migration to ESM, to allow the newer `@actions/*` packages. Two things worth confirming, both checked:

- `cache: 'pnpm'` is still supported in v7 — used by `tests.yaml` and `code-coverage.yaml`.
- v7 drops the dummy `NODE_AUTH_TOKEN` export, which only applies when `registry-url` is set. No workflow in this repo sets it, so publishing in `release.yaml` is unaffected.

No workflow edits beyond the version bump were needed.

One coverage gap to flag: `release.yaml` only triggers on `release`/`workflow_dispatch`, so its `setup-node@v7` step is not exercised by this PR's checks. Its usage is identical to `code-coverage.yaml` minus the `cache` input, which is covered here.

---
_Generated by [Claude Code](https://claude.ai/code/session_017yE8zYCcXS9wG6NfmwNAdg)_