### PR TITLE
release: v1.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyphen/browser-sdk",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Hyphen SDK for Browser / Javascript",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release summary

Patch release cutting `@hyphen/browser-sdk@1.1.5`. Dependency maintenance only — `src/` is untouched since `v1.1.4`; the one consumer-visible change is the `hookified` runtime bump.

## @hyphen/browser-sdk@1.1.5 — 2026-07-24

Dependency maintenance release; picks up hookified 3.0.1 listener fixes in the browser bundle.

### Bug Fixes
- upgrade hookified to 3.0.1, picking up upstream fixes for once-listener removal and for `emit` iterating a snapshot so it survives mid-emit mutation (5d96483, #73)

### Internal
- upgrade code quality dependencies — `@biomejs/biome` 2.5.5, `vitest` and `@vitest/coverage-v8` 4.1.10, `@hyphen/sdk` 4.0.1 (544798f, #69)
- upgrade TypeScript and build tooling — `@types/node` 24.13.3, `@swc/core` 1.15.46, `tsdown` 0.22.13 (31681ca, #70)
- upgrade GitHub Actions — `actions/setup-node` v6 to v7 (8577380, #71)
- upgrade TypeScript to 7.0.2; emitted output is byte-identical to 6.0.3 (8a6e264, #72)
- upgrade the pnpm `packageManager` pin to 11.15.1 (a91f759, #74)

### Contributors
- @jaredwray (6)

### Full List of Changes
- root - chore: upgrade code quality dependencies by @jaredwray in #69
- root - chore: upgrade TypeScript and build tooling by @jaredwray in #70
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #71
- root - chore: upgrade TypeScript to 7.0.2 (breaking) by @jaredwray in #72
- root - chore: upgrade hookified and pnpm package manager by @jaredwray in #73
- root - chore: upgrade pnpm package manager by @jaredwray in #74

**Full diff:** https://github.com/Hyphen/browser-sdk/compare/v1.1.4...v1.1.5

## Verification

- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes locally — 156 tests, 100% statements / 94.44% branches
- [x] `pnpm test:ci` passes locally
- [x] No uncommitted changes outside the version bump

## Notes for the reviewer

Two things that could read wrong at a glance:

- **`(breaking)` in the #71 and #72 titles is not a consumer break.** Both refer to upstream tooling majors — `actions/setup-node` v6→v7 and TypeScript 6→7. `src/` and `test/` are untouched across this range, and TypeScript 7 emitted byte-identical build output. Hence patch, not major.
- **#73's title mentions the pnpm pin, but only `hookified` landed in it.** The pnpm bump missed that merge by about two minutes and shipped separately in #74. The inventory above keeps the real PR titles; the categorized sections attribute each change to where it actually landed.

This repo keeps no `CHANGELOG.md`, so these notes live here and in the eventual GitHub Release.

This session is pinned to the `claude/browser-sdk-dependency-maintenance-23z2gq` branch, so the PR does not come from a `release/v1.1.5` branch as it normally would. The branch name is left over from the dependency-maintenance run; the commit is the version bump alone.

## Post-merge

Merge, then create a GitHub Release at tag `v1.1.5` — `release.yaml` triggers on `release: types: [released]` and publishes to npm via OIDC trusted publishing.

---
_Generated by [Claude Code](https://claude.ai/code/session_017yE8zYCcXS9wG6NfmwNAdg)_